### PR TITLE
Fix import paths in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import ReactFlow, { MiniMap, Controls, Background } from '@xyflow/react';
-import '@xyflow/react/dist/style.css';
+import React from './node_modules/react';
+import ReactDOM from './node_modules/react-dom/client';
+import ReactFlow, { MiniMap, Controls, Background } from './node_modules/@xyflow/react';
+import './node_modules/@xyflow/react/dist/style.css';
 
 const aboutMeNode = {
   id: '1',


### PR DESCRIPTION
Update import statements in `script.js` to use relative paths.

* Change the import statement for `react` to use a relative path
* Change the import statement for `react-dom/client` to use a relative path
* Change the import statement for `@xyflow/react` to use a relative path
* Change the import statement for `@xyflow/react/dist/style.css` to use a relative path

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/2187Nick/2187Nick.github.io?shareId=8de3ee4e-3b34-4288-bd1c-d705d6796430).